### PR TITLE
feat: support RustOwl v0.2.0, drop support for older versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 group = "jp.s6n.idea"
 
-version = "0.2.2"
+version = "0.3.0"
 
 kotlin { jvmToolchain(21) }
 
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        rustRover("251.23774.119") // 2025.1 EAP 6
+        rustRover("251.23774.316") // 2025.1 EAP 9
         pluginVerifier()
     }
 }

--- a/src/main/kotlin/jp/s6n/idea/rustowl/RustOwlFinder.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/RustOwlFinder.kt
@@ -7,10 +7,10 @@ import com.intellij.util.application
 import java.io.File
 
 @Service(Service.Level.APP)
-class CargoOwlspFinder {
-    fun find(): File? = PathEnvironmentVariableUtil.findExecutableInPathOnAnyOS("cargo-owlsp")
+class RustOwlFinder {
+    fun find(): File? = PathEnvironmentVariableUtil.findExecutableInPathOnAnyOS("rustowl")
 
     companion object {
-        @JvmStatic fun getInstance(): CargoOwlspFinder = application.service()
+        @JvmStatic fun getInstance(): RustOwlFinder = application.service()
     }
 }

--- a/src/main/kotlin/jp/s6n/idea/rustowl/highlighting/RustOwlHighlighter.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/highlighting/RustOwlHighlighter.kt
@@ -49,6 +49,7 @@ class RustOwlHighlighter(private val editor: Editor) {
                     "mut_borrow" -> settings.mutableBorrowingColor
                     "call",
                     "move" -> settings.valueMovedColor
+                    "shared_mut",
                     "outlive" -> settings.lifetimeErrorColor
                     else -> {
                         logger.warn("Unexpected decoration type: ${decoration.type}")

--- a/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLsp4jClient.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLsp4jClient.kt
@@ -1,0 +1,10 @@
+package jp.s6n.idea.rustowl.lsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.Lsp4jClient
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
+
+class RustOwlLsp4jClient(
+    project: Project,
+    serverNotificationsHandler: LspServerNotificationsHandler,
+) : Lsp4jClient(RustOwlLspNotificationHandler(project, serverNotificationsHandler))

--- a/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLspNotificationHandler.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLspNotificationHandler.kt
@@ -1,0 +1,116 @@
+package jp.s6n.idea.rustowl.lsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.platform.ide.progress.withBackgroundProgress
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
+import com.intellij.platform.util.progress.reportRawProgress
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.runBlocking
+import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.jetbrains.concurrency.runAsync
+
+sealed interface Progress {
+    data class InProgress(val text: String, val percentage: Int) : Progress
+
+    data object Done : Progress
+}
+
+class RustOwlLspNotificationHandler(
+    private val project: Project,
+    private val delegate: LspServerNotificationsHandler,
+    private val progress: MutableMap<Either<String, Int>, Channel<Progress>> = mutableMapOf(),
+) : LspServerNotificationsHandler {
+    override fun applyEdit(params: ApplyWorkspaceEditParams) = delegate.applyEdit(params)
+
+    override fun configuration(params: ConfigurationParams) = delegate.configuration(params)
+
+    override fun createProgress(params: WorkDoneProgressCreateParams) =
+        delegate.createProgress(params)
+
+    override fun logMessage(params: MessageParams) = delegate.logMessage(params)
+
+    override fun logTrace(params: LogTraceParams) = delegate.logTrace(params)
+
+    override fun publishDiagnostics(params: PublishDiagnosticsParams) =
+        delegate.publishDiagnostics(params)
+
+    override fun refreshCodeLenses() = delegate.refreshCodeLenses()
+
+    override fun refreshDiagnostics() = delegate.refreshDiagnostics()
+
+    override fun refreshInlayHints() = delegate.refreshInlayHints()
+
+    override fun refreshInlineValues() = delegate.refreshInlineValues()
+
+    override fun refreshSemanticTokens() = delegate.refreshSemanticTokens()
+
+    override fun registerCapability(params: RegistrationParams) =
+        delegate.registerCapability(params)
+
+    override fun showDocument(params: ShowDocumentParams) = delegate.showDocument(params)
+
+    override fun showMessage(params: MessageParams) = delegate.showMessage(params)
+
+    override fun showMessageRequest(params: ShowMessageRequestParams) =
+        delegate.showMessageRequest(params)
+
+    override fun telemetryEvent(`object`: Any) = delegate.telemetryEvent(`object`)
+
+    override fun unregisterCapability(params: UnregistrationParams) =
+        delegate.unregisterCapability(params)
+
+    override fun workspaceFolders() = delegate.workspaceFolders()
+
+    override fun notifyProgress(params: ProgressParams) {
+        if (!params.value.isLeft) {
+            return
+        }
+
+        val value = params.value.left
+        when (value.kind!!) {
+            WorkDoneProgressKind.begin -> {
+                val channel = Channel<Progress>()
+                val payload = value as WorkDoneProgressBegin
+
+                progress[params.token] = channel
+
+                runAsync {
+                    runBlocking {
+                        withBackgroundProgress(project, payload.title, payload.cancellable) {
+                            @Suppress("UnstableApiUsage")
+                            reportRawProgress { reporter ->
+                                while (true) {
+                                    when (val progress = channel.receive()) {
+                                        is Progress.InProgress -> {
+                                            reporter.text(progress.text)
+                                            reporter.fraction(progress.percentage / 100.0)
+                                        }
+
+                                        is Progress.Done -> {
+                                            break
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            WorkDoneProgressKind.report -> {
+                val payload = value as WorkDoneProgressReport
+                val channel = progress[params.token] ?: return
+
+                channel.trySendBlocking(Progress.InProgress(payload.message, payload.percentage))
+            }
+
+            WorkDoneProgressKind.end -> {
+                val channel = progress[params.token] ?: return
+
+                channel.trySendBlocking(Progress.Done)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLspServerDescriptor.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLspServerDescriptor.kt
@@ -3,16 +3,25 @@ package jp.s6n.idea.rustowl.lsp
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import java.io.File
+import org.eclipse.lsp4j.ClientCapabilities
 
 class RustOwlLspServerDescriptor(project: Project, private val owlspFile: File) :
     ProjectWideLspServerDescriptor(project, "RustOwl") {
     override val lsp4jServerClass = RustOwlLsp4jServer::class.java
 
+    override val clientCapabilities: ClientCapabilities
+        get() = super.clientCapabilities.apply { window.workDoneProgress = true }
+
     override fun isSupportedFile(file: VirtualFile) = file.extension == "rs"
 
     override fun getLanguageId(file: VirtualFile) = "rust"
 
-    override fun createCommandLine() = GeneralCommandLine(owlspFile.path)
+    override fun createCommandLine() =
+        GeneralCommandLine(owlspFile.path).apply { addParameter("--stdio") }
+
+    override fun createLsp4jClient(handler: LspServerNotificationsHandler) =
+        RustOwlLsp4jClient(project, handler)
 }

--- a/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLspServerSupportProvider.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/lsp/RustOwlLspServerSupportProvider.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import java.io.File
-import jp.s6n.idea.rustowl.CargoOwlspFinder
+import jp.s6n.idea.rustowl.RustOwlFinder
 import jp.s6n.idea.rustowl.settings.RustOwlSettings
 
 class RustOwlLspServerSupportProvider : LspServerSupportProvider {
@@ -19,13 +19,13 @@ class RustOwlLspServerSupportProvider : LspServerSupportProvider {
         if (file.extension != "rs") return
 
         val owlspFile =
-            RustOwlSettings.getInstance().cargoOwlspPath.ifEmpty { null }?.let { File(it) }
-                ?: CargoOwlspFinder.getInstance().find()
+            RustOwlSettings.getInstance().rustowlPath.ifEmpty { null }?.let { File(it) }
+                ?: RustOwlFinder.getInstance().find()
                 ?: return Notifications.Bus.notify(
                     Notification(
                         "RustOwl",
                         "RustOwl is not installed",
-                        "Could not find cargo-owlsp in the PATH.",
+                        "Could not find rustowl in the PATH.",
                         NotificationType.ERROR,
                     )
                 )

--- a/src/main/kotlin/jp/s6n/idea/rustowl/settings/RustOwlSettings.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/settings/RustOwlSettings.kt
@@ -9,10 +9,10 @@ import java.awt.Color
 @State(name = "RustOwlSettings", storages = [(Storage("rustowl.xml"))])
 class RustOwlSettings :
     SimplePersistentStateComponent<RustOwlSettingsState>(RustOwlSettingsState()) {
-    var cargoOwlspPath: String
-        get() = state.cargoOwlspPath ?: ""
+    var rustowlPath: String
+        get() = state.rustowlPath ?: ""
         set(value) {
-            state.cargoOwlspPath = value
+            state.rustowlPath = value
         }
 
     var lifetimeColor: Color

--- a/src/main/kotlin/jp/s6n/idea/rustowl/settings/RustOwlSettingsConfigurable.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/settings/RustOwlSettingsConfigurable.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.emptyText
 import com.intellij.ui.dsl.builder.*
-import jp.s6n.idea.rustowl.CargoOwlspFinder
+import jp.s6n.idea.rustowl.RustOwlFinder
 import jp.s6n.idea.rustowl.ui.*
 
 class RustOwlSettingsConfigurable :
@@ -13,13 +13,14 @@ class RustOwlSettingsConfigurable :
 
     override fun createPanel(): DialogPanel = panel {
         group("RustOwl Settings") {
-            row("Path to cargo-owlsp:") {
-                textFieldWithBrowseButton("Choose cargo-owlsp executable")
+            row("Path to rustowl:") {
+                @Suppress("UnstableApiUsage")
+                textFieldWithBrowseButton("Choose rustowl executable")
                     .align(Align.FILL)
-                    .bindText(settings::cargoOwlspPath)
+                    .bindText(settings::rustowlPath)
                     .run {
                         component.emptyText.setText(
-                            CargoOwlspFinder.getInstance().find()?.let { "Auto-detected: $it" }
+                            RustOwlFinder.getInstance().find()?.let { "Auto-detected: $it" }
                                 ?: "Could not auto-detect cargo-owlsp from the PATH"
                         )
                     }
@@ -38,7 +39,7 @@ class RustOwlSettingsConfigurable :
             row("Value Moved / Function Call:") {
                 colorField().withTransparency().bindColor(settings::valueMovedColor)
             }
-            row("Lifetime Error:") {
+            row("Shared Mutable / Lifetime Error:") {
                 colorField().withTransparency().bindColor(settings::lifetimeErrorColor)
             }
         }

--- a/src/main/kotlin/jp/s6n/idea/rustowl/settings/RustOwlSettingsState.kt
+++ b/src/main/kotlin/jp/s6n/idea/rustowl/settings/RustOwlSettingsState.kt
@@ -3,7 +3,7 @@ package jp.s6n.idea.rustowl.settings
 import com.intellij.openapi.components.BaseState
 
 class RustOwlSettingsState : BaseState() {
-    var cargoOwlspPath by string()
+    var rustowlPath by string()
 
     var lifetimeColor by string()
     var immutableBorrowingColor by string()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,21 +28,15 @@
   ]]></description>
 
   <change-notes><![CDATA[
-    <h2>v0.2.2</h2>
+    <h2>v0.3.0</h2>
+    <h3>Breaking Changes</h3>
+    <ul>
+     <li>Old versions of RustOwl (< 0.2.0) is not supported anymore.</li>
+    </ul>
     <h3>Features</h3>
     <ul>
-      <li>Added support for 2025.1 EAP.</li>
-    </ul>
-    <h2>v0.2.1</h2>
-    <h3>Fixes</h3>
-    <ul>
-      <li>Fixed the customised colour settings are not used on highlighting.</li>
-    </ul>
-    <h2>v0.2.0</h2>
-    <h3>Features</h3>
-    <ul>
-      <li>Added settings to specify the path to cargo-owlsp.</li>
-      <li>Added settings to customise highlighting colours.</li>
+      <li>Added the plugin icon from the RustOwl official logo.</li>
+      <li>Support RustOwl v0.2.0.</li>
     </ul>
   ]]></change-notes>
 


### PR DESCRIPTION
Closes #12 

Added support for RustOwl v0.2.0, which has been released today.

As RustOwl introduced some breaking changes in the release, I decided to drop support for older version since v0.3.0 of this plugin. Please upgrade your RustOwl installation before upgrading this plugin.

We now have a progress indicator while RustOwl is analysing the code ✨
Big Kudos to @cordx56 for implementing the progress reporting feature on RustOwl. <3

<img width="409" alt="image" src="https://github.com/user-attachments/assets/6e30d7f3-a36b-4506-a674-fa799a941df8" />

